### PR TITLE
Unescape all C-string escape sequences

### DIFF
--- a/lib/po.js
+++ b/lib/po.js
@@ -100,8 +100,20 @@ PO.parse = function(data) {
   function extract(string) {
     string = trim(string);
     string = string.replace(/^[^"]*"|"$/g, '');
-    string = string.replace(/\\"/g, '"');
-    string = string.replace(/\\\\/g, '\\');
+    string = string.replace(/\\([abtnvfr'"\\?]|([0-7]{3})|x([0-9a-fA-F]{2}))/g, function(match, esc, oct, hex) {
+      if(oct) return String.fromCharCode(parseInt(oct, 8));
+      if(hex) return String.fromCharCode(parseInt(hex, 16));
+      switch(esc) {
+        case 'a': return '\x07';
+        case 'b': return '\b';
+        case 't': return '\t';
+        case 'n': return '\n';
+        case 'v': return '\v';
+        case 'f': return '\f';
+        case 'r': return '\r';
+        default: return esc;
+      }
+    });
     return string;
   };
 


### PR DESCRIPTION
http://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/PO-Files.html says that strings within a PO file should be treated like C strings. Currently, node-po only unescapes the escape sequences \" and \\. My patch adds support for the other escape sequences, I find newlines particularly important.
