### PR TITLE
Update parsing of headers

### DIFF
--- a/lib/po.js
+++ b/lib/po.js
@@ -81,7 +81,7 @@ PO.parse = function(data) {
       header = header.trim().replace(/^"/, '').replace(/\\n"$/, '');
       var p = header.split(/:/)
         , name = p.shift().trim()
-        , value = p.join(':').trim().replace(/n$/);
+        , value = p.join(':').trim();
       po.headers[name] = value;
     }
   });


### PR DESCRIPTION
Remove wrong `.replace()` statement which breaks any language file from a language ending with the character `n`. It is unclear to me why this replace is even there. As it is even invalid to replace without supplying a string with what it needs to be replaced.

**The problem:**
a PO file with `Language: en/n` is parsed as `eundefined` because the ending `n` is replaced with a missing variable.

**The Fix in this pull request:**
fix for issue #7 
the replace is removed all together as it suits no real purpose. 
