### PR TITLE
Output comments in PO.Item.toString()

### DIFF
--- a/lib/po.js
+++ b/lib/po.js
@@ -181,6 +181,12 @@ PO.Item.prototype.toString = function() {
     });
   }
 
+  if (this.comments.length > 0) {
+    this.comments.forEach(function(ref) {
+      lines.push(util.format('#%s', ref));
+    });
+  }
+
   ['msgid', 'msgid_plural', 'msgstr'].forEach(function(keyword) {
     var text = that[keyword];
     if (text != null) {


### PR DESCRIPTION
Comments in the source PO file were being correctly parsed but omitted from the output. This PR includes comments in the output.